### PR TITLE
Update converter to .NET 8 and handle mismatched byte terminators

### DIFF
--- a/Docs/SavesFormat.md
+++ b/Docs/SavesFormat.md
@@ -1,0 +1,8 @@
+# Save Game Converter Usage
+
+This tool converts Unreal Engine save game files to JSON. The converter requires the .NET 8 runtime.
+
+1. Install [.NET 8](https://dotnet.microsoft.com/download) on your system.
+2. Build the converter with `dotnet build`.
+3. Run `dotnet GvasConverter.dll <path to .sav>` to convert a save file.
+

--- a/GvasConverter/GvasConverter.csproj
+++ b/GvasConverter/GvasConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/GvasFormat/Serialization/UETypes/UEByteProperty.cs
+++ b/GvasFormat/Serialization/UETypes/UEByteProperty.cs
@@ -15,8 +15,10 @@ namespace GvasFormat.Serialization.UETypes
         public static UEByteProperty Read(BinaryReader reader, long valueLength)
         {
             var terminator = reader.ReadByte();
-            if (terminator != 0)
-                throw new FormatException($"Offset: 0x{reader.BaseStream.Position - 1:x8}. Expected terminator (0x00), but was (0x{terminator:x2})");
+            // Some games incorrectly store a non-zero value here. Skip any
+            // non-zero bytes instead of failing the read.
+            while (terminator != 0 && reader.BaseStream.Position < reader.BaseStream.Length)
+                terminator = reader.ReadByte();
 
             // valueLength starts here
             var arrayLength = reader.ReadInt32();


### PR DESCRIPTION
## Summary
- target .NET 8 for the console converter
- ignore non-zero terminators when reading UE byte properties
- document basic usage and the .NET 8 requirement

## Testing
- `dotnet build gvas.sln`
- `dotnet run --project GvasConverter/GvasConverter.csproj tests/Axle.sav`
- `dotnet run --project GvasConverter/GvasConverter.csproj tests/Chief.sav`
- `dotnet run --project GvasConverter/GvasConverter.csproj tests/Profile.sav` *(fails: Unknown value type 'SetProperty')*

------
https://chatgpt.com/codex/tasks/task_b_686787d8e5fc8324b1d82a60a52fef96