### PR TITLE
Fix hex byte array allocation

### DIFF
--- a/GvasFormat/Utils/StringEx.cs
+++ b/GvasFormat/Utils/StringEx.cs
@@ -31,7 +31,7 @@ namespace GvasFormat.Utils
             if (hex.Length %2 == 1)
                 throw new InvalidOperationException($"Odd hex string length of {hex.Length}");
 
-            var result = new byte[hex.Length % 2];
+            var result = new byte[hex.Length / 2];
             for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
                 result[j] = byte.Parse(hex.Substring(i, 2), NumberStyles.HexNumber);
             return result;


### PR DESCRIPTION
## Summary
- fix byte array size when converting hex strings
- build solution with .NET 8

## Testing
- `dotnet build gvas.sln`
- `dotnet test gvas.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68678be06d4083248c8c068c86b53ee9