### PR TITLE
Add tests for serialization helpers

### DIFF
--- a/GvasFormat.Tests/BinaryReaderExTests.cs
+++ b/GvasFormat.Tests/BinaryReaderExTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Text;
+using GvasFormat.Serialization;
+
+namespace GvasFormat.Tests;
+
+public class BinaryReaderExTests
+{
+    [Fact]
+    public void WriteRead_NullString()
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+            writer.WriteUEString(null);
+
+        Assert.Equal(new byte[] { 0, 0, 0, 0 }, ms.ToArray());
+
+        ms.Position = 0;
+        using var reader = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true);
+        var value = reader.ReadUEString();
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void WriteRead_EmptyString()
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+            writer.WriteUEString(string.Empty);
+
+        Assert.Equal(new byte[] { 1, 0, 0, 0, 0 }, ms.ToArray());
+
+        ms.Position = 0;
+        using var reader = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true);
+        var value = reader.ReadUEString();
+        Assert.Equal(string.Empty, value);
+    }
+
+    [Fact]
+    public void WriteRead_TypicalString()
+    {
+        const string input = "Hello";
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+            writer.WriteUEString(input);
+
+        ms.Position = 0;
+        using var reader = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true);
+        var value = reader.ReadUEString();
+        Assert.Equal(input, value);
+    }
+}

--- a/GvasFormat.Tests/GlobalUsings.cs
+++ b/GvasFormat.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+

--- a/GvasFormat.Tests/GvasFormat.Tests.csproj
+++ b/GvasFormat.Tests/GvasFormat.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference Include="..\GvasFormat\GvasFormat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GvasFormat.Tests/StringExTests.cs
+++ b/GvasFormat.Tests/StringExTests.cs
@@ -1,0 +1,31 @@
+using System;
+using GvasFormat.Utils;
+
+namespace GvasFormat.Tests;
+
+public class StringExTests
+{
+    [Fact]
+    public void AsHex_AsBytes_RoundTrip()
+    {
+        var bytes = new byte[] { 0x00, 0x01, 0xAB, 0xFF };
+        var hex = bytes.AsHex();
+        var roundTrip = hex.AsBytes();
+        Assert.Equal(bytes, roundTrip);
+    }
+
+    [Fact]
+    public void AsBytes_AsHex_RoundTrip()
+    {
+        const string hex = "0a0b0c";
+        var bytes = hex.AsBytes();
+        var roundTrip = bytes.AsHex();
+        Assert.Equal(hex, roundTrip);
+    }
+
+    [Fact]
+    public void AsBytes_Throws_On_Odd_Length()
+    {
+        Assert.Throws<InvalidOperationException>(() => "abc".AsBytes());
+    }
+}

--- a/GvasFormat/Utils/StringEx.cs
+++ b/GvasFormat/Utils/StringEx.cs
@@ -31,7 +31,7 @@ namespace GvasFormat.Utils
             if (hex.Length %2 == 1)
                 throw new InvalidOperationException($"Odd hex string length of {hex.Length}");
 
-            var result = new byte[hex.Length % 2];
+            var result = new byte[hex.Length / 2];
             for (int i = 0, j = 0; i < hex.Length; i += 2, j++)
                 result[j] = byte.Parse(hex.Substring(i, 2), NumberStyles.HexNumber);
             return result;

--- a/gvas.sln
+++ b/gvas.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GvasFormat", "GvasFormat\Gv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GvasConverter", "GvasConverter\GvasConverter.csproj", "{F618BACD-D0A4-409D-B74B-29D0BFFB803F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GvasFormat.Tests", "GvasFormat.Tests\GvasFormat.Tests.csproj", "{1F623D9A-04C1-4D4A-97DB-4D78AB3C1327}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{F618BACD-D0A4-409D-B74B-29D0BFFB803F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F618BACD-D0A4-409D-B74B-29D0BFFB803F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F618BACD-D0A4-409D-B74B-29D0BFFB803F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F623D9A-04C1-4D4A-97DB-4D78AB3C1327}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F623D9A-04C1-4D4A-97DB-4D78AB3C1327}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F623D9A-04C1-4D4A-97DB-4D78AB3C1327}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F623D9A-04C1-4D4A-97DB-4D78AB3C1327}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add xunit test project
- cover `BinaryReaderEx` string helpers
- cover `StringEx` helpers
- fix `AsBytes` byte array allocation bug

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_68678be03f888324a835f7a215ee007b